### PR TITLE
Extract PageLinks and show links on 404

### DIFF
--- a/src/app/components/PageLinks.tsx
+++ b/src/app/components/PageLinks.tsx
@@ -1,0 +1,15 @@
+export function PageLinks() {
+  return (
+    <div className="flex flex-row gap-2 justify-center">
+      <a href="/nav/page-1" className="text-blue-500">
+        Page 1
+      </a>
+      <a href="/nav/page-2" className="text-blue-500">
+        Page 2
+      </a>
+      <a href="/nav/page-3" className="text-blue-500">
+        Page 3 (404)
+      </a>
+    </div>
+  );
+}

--- a/src/app/pages/nav/Layout.tsx
+++ b/src/app/pages/nav/Layout.tsx
@@ -1,5 +1,6 @@
 import { LayoutProps } from "rwsdk/router";
 import { ToggleNavigationModes } from "@/app/components/ToggleNavigationModes";
+import { PageLinks } from "@/app/components/PageLinks";
 
 export const ViewTransitionLayout = ({ children }: LayoutProps) => {
   return (
@@ -22,18 +23,7 @@ export const ViewTransitionLayout = ({ children }: LayoutProps) => {
       </div>
 
       <br />
-      <div className="flex flex-row gap-2 justify-center">
-        <a href="/nav/page-1" className="text-blue-500">
-          Page 1
-        </a>
-        <a href="/nav/page-2" className="text-blue-500">
-          Page 2
-        </a>
-        <a href="/nav/page-3" className="text-blue-500">
-          Page 3 (404)
-        </a>
-      </div>
-
+      <PageLinks />
       {children}
     </div>
   );

--- a/src/app/pages/nav/routes.tsx
+++ b/src/app/pages/nav/routes.tsx
@@ -4,6 +4,7 @@ import { renderToStream } from "rwsdk/worker";
 
 import { ViewTransitionLayout } from "./Layout";
 import { Document } from "@/app/Document";
+import { PageLinks } from "@/app/components/PageLinks";
 
 export const routes = [
   layout(ViewTransitionLayout, [
@@ -40,7 +41,8 @@ export const routes = [
   ]),
   route("/*", async () => {
     const stream = await renderToStream(
-      <div className="flex flex-col items-center justify-center h-screen">
+      <div className="flex flex-col items-center justify-center min-h-[25vh]">
+        <PageLinks />
         <h1 className="text-4xl font-bold">404</h1>
         <p className="text-2xl">Page not found</p>
       </div>,


### PR DESCRIPTION
Demonstrates issue with 404 and client-side nav. 
After triggering the 404, links to other pages will no longer work as expected.

#### hit 404 by clicking on link for page 3
<img width="1216" height="283" alt="Screenshot 2025-07-31 at 20 39 56" src="https://github.com/user-attachments/assets/9e116b7a-0193-4c90-8de9-e411dbb99eec" />

#### click on link for page 1
<img width="1220" height="828" alt="Screenshot 2025-07-31 at 20 40 10" src="https://github.com/user-attachments/assets/8bbc1cfd-34c0-41c9-890c-98b529dd554f" />
